### PR TITLE
Start httpd in :stand_alone mode so that it's cleaned up in error cases

### DIFF
--- a/lib/acmev2.ex
+++ b/lib/acmev2.ex
@@ -541,13 +541,17 @@ defmodule Acmev2 do
     ipfamily = if tuple_size(bind_address) == 4, do: :inet, else: :inet6
 
     {:ok, pid} =
-      :inets.start(:httpd,
-        port: port,
-        bind_address: bind_address,
-        ipfamily: ipfamily,
-        server_name: ~c"http_challenge",
-        server_root: ~c"./",
-        document_root: String.to_charlist(base)
+      :inets.start(
+        :httpd,
+        [
+          port: port,
+          bind_address: bind_address,
+          ipfamily: ipfamily,
+          server_name: ~c"http_challenge",
+          server_root: ~c"./",
+          document_root: String.to_charlist(base)
+        ],
+        :stand_alone
       )
 
     pid


### PR DESCRIPTION
Without this the pid will always stay up, and further requests will then fail with an `:already_started` error like this:

```
Sep 16 07:22:52 kinecorman kine_corman[114]:             ** (MatchError) no match of right hand side value: {:error, {:already_started, #PID<0.3445.0>}}
Sep 16 07:22:52 kinecorman kine_corman[114]:                 (zerossl 1.0.0) lib/acmev2.ex:543: Acmev2.serve/1
Sep 16 07:22:52 kinecorman kine_corman[114]:                 (zerossl 1.0.0) lib/acmev2.ex:768: Acmev2.do_gen_cert/2
Sep 16 07:22:52 kinecorman kine_corman[114]:                 (certmagex 1.0.4) lib/certmagex/worker.ex:25: CertMagex.Worker.handle_call/3
Sep 16 07:22:52 kinecorman kine_corman[114]:                 (stdlib 6.0.1) gen_server.erl:2209: :gen_server.try_handle_call/4
Sep 16 07:22:52 kinecorman kine_corman[114]:                 (stdlib 6.0.1) gen_server.erl:2238: :gen_server.handle_msg/6
Sep 16 07:22:52 kinecorman kine_corman[114]:                 (stdlib 6.0.1) proc_lib.erl:329: :proc_lib.init_p_do_apply/3
```